### PR TITLE
Allow marking flights as hike&fly

### DIFF
--- a/migrations/2020-07-10-230818_hikeandfly/down.sql
+++ b/migrations/2020-07-10-230818_hikeandfly/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE flights
+    DROP COLUMN hikeandfly;

--- a/migrations/2020-07-10-230818_hikeandfly/up.sql
+++ b/migrations/2020-07-10-230818_hikeandfly/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE flights
+    ADD COLUMN hikeandfly BOOLEAN NOT NULL DEFAULT false;

--- a/src/data.rs
+++ b/src/data.rs
@@ -335,6 +335,23 @@ pub fn get_flight_count_per_year_for_user(conn: &PgConnection, user: &User) -> V
     .expect("Error loading flight count stats")
 }
 
+/// Get hike&fly count per year for the specified user.
+pub fn get_hikeandfly_count_per_year_for_user(conn: &PgConnection, user: &User) -> Vec<FlightCount> {
+    sql_query(
+        "SELECT date_part('year', launch_time)::smallint as year,
+                count(*) as count
+           FROM flights
+          WHERE user_id = $1
+            AND launch_time IS NOT NULL
+            AND hikeandfly = true
+          GROUP BY year
+          ORDER BY year DESC",
+    )
+    .bind::<Integer, _>(user.id)
+    .load::<FlightCount>(conn)
+    .expect("Error loading hike&fly count stats")
+}
+
 #[derive(Debug, QueryableByName)]
 pub struct FlightTime {
     #[sql_type = "SmallInt"]

--- a/src/flights.rs
+++ b/src/flights.rs
@@ -210,6 +210,7 @@ pub(crate) struct FlightForm {
     launch_date: OptionResult<NaiveDate>,
     launch_time: OptionResult<NaiveTime>,
     landing_time: OptionResult<NaiveTime>,
+    hikeandfly: bool,
     track_distance: OptionResult<f32>,
     xcontest_tracktype: String,
     xcontest_distance: OptionResult<f32>,
@@ -302,6 +303,7 @@ impl FlightForm {
             let ndt = NaiveDateTime::new(launch_date_naive.unwrap(), time);
             DateTime::from_utc(ndt, Utc) // TODO: Timezone
         });
+        let hikeandfly = self.hikeandfly;
 
         // Extract track information
         let track_distance = match self.track_distance.into_result() {
@@ -329,6 +331,7 @@ impl FlightForm {
             landing_at,
             launch_time,
             landing_time,
+            hikeandfly,
             track_distance,
             xcontest_tracktype,
             xcontest_distance,
@@ -505,6 +508,7 @@ pub(crate) fn edit(
     flight.landing_at = new_flight.landing_at;
     flight.launch_time = new_flight.launch_time;
     flight.landing_time = new_flight.landing_time;
+    flight.hikeandfly = new_flight.hikeandfly;
     flight.track_distance = new_flight.track_distance;
     flight.xcontest_tracktype = new_flight.xcontest_tracktype;
     flight.xcontest_distance = new_flight.xcontest_distance;

--- a/src/models.rs
+++ b/src/models.rs
@@ -150,6 +150,8 @@ pub struct Flight {
     pub igc: Option<Vec<u8>>,
     /// When the flight was entered into Flugbuech
     pub created_at: DateTime<Utc>,
+    /// Whether you hiked up to launch
+    pub hikeandfly: bool,
 }
 
 #[derive(Insertable, Default)]
@@ -183,4 +185,6 @@ pub struct NewFlight {
     pub video_url: Option<String>,
     /// IGC file contents
     pub igc: Option<Vec<u8>>,
+    /// Whether you hiked up to launch
+    pub hikeandfly: bool,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -21,6 +21,7 @@ table! {
         video_url -> Nullable<Text>,
         igc -> Nullable<Bytea>,
         created_at -> Timestamptz,
+        hikeandfly -> Bool,
     }
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -16,7 +16,8 @@ use crate::{
 
 #[derive(Default, Serialize)]
 struct YearStats {
-    flights: Option<u32>,
+    flight_count: Option<u32>,
+    hikeandfly_count: Option<u32>,
     flight_seconds: Option<u64>,
     distance_track: Option<i32>,
     distance_track_incomplete: bool,
@@ -31,6 +32,7 @@ struct StatsContext {
     landing_locations: Vec<LocationWithCount>,
     yearly_stats: BTreeMap<u16, YearStats>,
     flight_count_total: u32,
+    hikeandfly_count_total: u32,
     flight_time_total: u64,
     flight_distance_total: (i32, i32), // (track, scored)
     flights_without_launch_time: u64,
@@ -55,9 +57,18 @@ pub(crate) fn stats(db: data::Database, user: auth::AuthUser) -> Template {
 
     // Get flight count per year
     for count in data::get_flight_count_per_year_for_user(&db, &user) {
-        yearly_stats.entry(count.year as u16).or_default().flights = Some(count.count as u32);
+        yearly_stats.entry(count.year as u16).or_default().flight_count = Some(count.count as u32);
     }
-    let flight_count_total = yearly_stats.values().filter_map(|s| s.flights).sum();
+    let flight_count_total = yearly_stats.values().filter_map(|s| s.flight_count).sum();
+
+    // Get hike&fly count per year
+    for count in data::get_hikeandfly_count_per_year_for_user(&db, &user) {
+        yearly_stats
+            .entry(count.year as u16)
+            .or_default()
+            .hikeandfly_count = Some(count.count as u32);
+    }
+    let hikeandfly_count_total = yearly_stats.values().filter_map(|s| s.hikeandfly_count).sum();
 
     // Get hours per year
     for time in data::get_flight_time_per_year_for_user(&db, &user) {
@@ -85,6 +96,7 @@ pub(crate) fn stats(db: data::Database, user: auth::AuthUser) -> Template {
         landing_locations,
         yearly_stats,
         flight_count_total,
+        hikeandfly_count_total,
         flight_time_total,
         flight_distance_total,
         flights_without_launch_time,

--- a/static/css/flugbuech.css
+++ b/static/css/flugbuech.css
@@ -90,3 +90,7 @@ footer {
 .flash-container {
     margin-bottom: 24px;
 }
+
+div.control + label.checkbox {
+    margin-top: 8px;
+}

--- a/templates/flight.tera
+++ b/templates/flight.tera
@@ -36,6 +36,7 @@
             <td>
                 {% if launch_at %}{{ macros::flag(country_code=launch_at.country) }} {{ launch_at.name }}, {{ launch_at.elevation }} mASL{% endif %}
                 {%- if flight.launch_time %}, {{ flight.launch_time | date(format="%H:%M") }} UTC{% endif %}
+                {%- if flight.hikeandfly %} <i class="fas fa-hiking" title="Hike &amp; Fly"></i>{% endif %}
             </td>
         </tr>
         <tr>

--- a/templates/flights.tera
+++ b/templates/flights.tera
@@ -43,7 +43,7 @@
                 <td>{% if flight.launch_time %}{{ flight.launch_time | date }}{% endif %}</td>
                 <td>{% if glider %}{{ glider.manufacturer }} {{ glider.model }}{% endif %}</td>
                 <td title="{% if launch_at %}{{ launch_at.elevation }} mASL{% endif %}">
-                    {% if launch_at %}{{ macros::flag(country_code=launch_at.country) }} {{ launch_at.name }}{% endif %}
+                    {% if launch_at %}{{ macros::flag(country_code=launch_at.country) }} {{ launch_at.name }}{% if flight.hikeandfly %}&nbsp;<i class="fas fa-hiking" title="Hike &amp; Fly"></i>{% endif %}{% endif %}
                 </td>
                 <td title="{% if landing_at %}{{ landing_at.elevation }} mASL{% endif %}">
                     {% if landing_at %}{{ macros::flag(country_code=landing_at.country) }} {{ landing_at.name }}{% endif %}

--- a/templates/stats.tera
+++ b/templates/stats.tera
@@ -16,6 +16,7 @@
                     <tr>
                         <th>Year</th>
                         <th>Flights</th>
+                        <th title="Hike &amp; Fly">H&amp;F</th>
                         <th>Hours</th>
                         <th>Track Distance</th>
                         <th>Scored Distance</th>
@@ -25,7 +26,8 @@
                     {% for year, stats in yearly_stats %}
                     <tr>
                         <td>{{ year }}</td>
-                        <td>{% if stats.flights %}{{ stats.flights }}{% else %}?{% endif %}</td>
+                        <td>{{ stats.flight_count }}</td>
+                        <td>{% if stats.hikeandfly_count %}{{ stats.hikeandfly_count }}{% else %}0{% endif %}</td>
                         <td>{% if stats.flight_seconds %}{{ stats.flight_seconds | duration }} h{% else %}?{% endif %}</td>
                         <td>{% if stats.distance_track %}{{ stats.distance_track }}{% else %}0{% endif %} km{% if stats.distance_track_incomplete %}&nbsp;<sup>{% if flights_without_launch_time > 0 %}2{% else %}1{% endif %}</sup>{% endif %}</td>
                         <td>{% if stats.distance_scored %}{{ stats.distance_scored }}{% else %}0{% endif %} km{% if stats.distance_scored_incomplete %}&nbsp;<sup>{% if flights_without_launch_time > 0 %}2{% else %}1{% endif %}</sup>{% endif %}</td>
@@ -34,6 +36,7 @@
                     <tr class="has-text-weight-medium">
                         <td>Total{% if flights_without_launch_time > 0 %}<sup>1</sup>{% endif %}</td>
                         <td>{{ flight_count_total }}</td>
+                        <td>{{ hikeandfly_count_total }}</td>
                         <td>{{ flight_time_total | duration }}</td>
                         <td>{% if flight_distance_total.0 %}{{ flight_distance_total.0 }}{% else %}0{% endif %} km</td>
                         <td>{% if flight_distance_total.1 %}{{ flight_distance_total.1 }}{% else %}0{% endif %} km</td>

--- a/templates/submit.tera
+++ b/templates/submit.tera
@@ -110,6 +110,10 @@ Currently locations cannot be created automatically.</p>
                 </div>
             </div>
         </div>
+        <label class="checkbox">
+            <input type="checkbox" id="hikeandfly" name="hikeandfly" {% if flight and flight.hikeandfly%}checked{% endif %}>
+            Hike &amp; Fly
+        </label>
     </div>
 
     <div class="column">


### PR DESCRIPTION
Add a checkbox to allow marking flights as hike&fly flights.

The hike&fly count is also included in the stats.

Fixes #38.