### PR TITLE
Fix flight datetime validation

### DIFF
--- a/src/flights.rs
+++ b/src/flights.rs
@@ -270,26 +270,32 @@ impl FlightForm {
         let mut date_parts = 0;
         let launch_date_naive = match self.launch_date.into_result() {
             Ok(val) => {
-                date_parts += 1;
+                if val.is_some() {
+                    date_parts += 1;
+                }
                 val
             },
             Err(e) => return Err(format!("Launch date: {}", e)),
         };
         let launch_time_naive = match self.launch_time.into_result() {
             Ok(val) => {
-                date_parts += 1;
+                if val.is_some() {
+                    date_parts += 1;
+                }
                 val
             },
             Err(e) => return Err(format!("Launch time: {}", e)),
         };
         let landing_time_naive = match self.landing_time.into_result() {
             Ok(val) => {
-                date_parts += 1;
+                if val.is_some() {
+                    date_parts += 1;
+                }
                 val
             },
             Err(e) => return Err(format!("Landing time: {}", e)),
         };
-        if date_parts < 0 && date_parts < 3 {
+        if date_parts > 0 && date_parts < 3 {
             return Err("If you specify launch date, launch time or landing time, \
                         then the other two values must be provided as well"
                 .into());

--- a/templates/flight_submit.tera
+++ b/templates/flight_submit.tera
@@ -334,6 +334,29 @@ Currently locations cannot be created automatically.</p>
         }
     }
 
+    function validateDateTimeFields() {
+        const launchDateField = document.getElementById('launchDate');
+        const launchTimeField = document.getElementById('launchTime');
+        const landingTimeField = document.getElementById('landingTime');
+
+        const launchDate = launchDateField.value;
+        const launchTime = launchTimeField.value;
+        const landingTime = landingTimeField.value;
+
+        const msg = 'Either all or no date/time fields must be filled out';
+
+        const filled = [launchDate.length > 0, launchTime.length > 0, landingTime.length > 0];
+        if (!filled.every(x => x === true) && !filled.every(x => x === false)) {
+            for (const field of [launchDateField, launchTimeField, landingTimeField]) {
+                field.setCustomValidity(msg);
+            }
+        } else {
+            for (const field of [launchDateField, launchTimeField, landingTimeField]) {
+                field.setCustomValidity('');
+            }
+        }
+    }
+
     function processData(data) {
         // Determine glider
         const gliderId = gliders.match(data.glidertype);
@@ -474,6 +497,12 @@ Currently locations cannot be created automatically.</p>
     document.getElementById('landingTime').addEventListener('change', recalculateDuration);
 
     recalculateDuration();
+
+    document.getElementById('launchDate').addEventListener('change', validateDateTimeFields);
+    document.getElementById('launchTime').addEventListener('change', validateDateTimeFields);
+    document.getElementById('landingTime').addEventListener('change', validateDateTimeFields);
+
+    validateDateTimeFields();
 </script>
 
 <script>


### PR DESCRIPTION
Disallow entering date without time, fix submission validation.

Fixes #41.

(Note: In the future, entering a date without time should be possible, but it requires adjusting some aggregation queries.)