### PR TITLE
Allow enabling plausible

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -324,6 +324,7 @@ mod tests {
     use crate::{
         templates,
         test_utils::{make_test_config, DbTestContext},
+        Config,
     };
 
     use super::*;
@@ -334,7 +335,7 @@ mod tests {
         test_routes.extend_from_slice(&routes![crate::profile::view]);
         let app = rocket::custom(make_test_config())
             .attach(data::Database::fairing())
-            .attach(templates::fairing())
+            .attach(templates::fairing(&Config::default()))
             .mount("/", test_routes);
         Client::tracked(app).expect("valid rocket instance")
     }

--- a/src/gliders.rs
+++ b/src/gliders.rs
@@ -243,6 +243,7 @@ mod tests {
     use crate::{
         flights, templates,
         test_utils::{make_test_config, DbTestContext},
+        Config,
     };
 
     use super::*;
@@ -251,7 +252,7 @@ mod tests {
     fn make_client() -> Client {
         let app = rocket::custom(make_test_config())
             .attach(data::Database::fairing())
-            .attach(templates::fairing())
+            .attach(templates::fairing(&Config::default()))
             .mount("/", routes![add, flights::submit]);
         Client::untracked(app).expect("valid rocket instance")
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,11 @@ pub const DESCRIPTION: &str = "Paragliding flight book.";
 
 // Config
 
-#[derive(Deserialize)]
-struct Config {
-    static_files_dir: Option<String>,
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct Config {
+    pub static_files_dir: Option<String>,
+    pub plausible_domain: Option<String>,
+    pub plausible_url: Option<String>,
 }
 
 // Index
@@ -133,7 +135,9 @@ async fn main() -> Result<()> {
         .to_string();
 
     // Attach fairings
-    let app = app.attach(data::Database::fairing()).attach(templates::fairing());
+    let app = app
+        .attach(data::Database::fairing())
+        .attach(templates::fairing(&config));
 
     // Register custom error catchers
     let app = app.register("/", catchers![service_not_available]);

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,10 +1,17 @@
+use std::{collections::HashMap, sync::Arc};
+
 use rocket::fairing::Fairing;
-use rocket_dyn_templates::Template;
+use rocket_dyn_templates::{
+    tera::{self, Value},
+    Template,
+};
 
-use crate::filters;
+use crate::{filters, Config};
 
-pub fn fairing() -> impl Fairing {
-    Template::custom(|engines| {
+pub fn fairing(config: &Config) -> impl Fairing {
+    let config = Arc::new(config.clone());
+
+    Template::custom(move |engines| {
         // Autoescape HTML and Tera files
         engines.tera.autoescape_on(vec![".html", ".tera"]);
 
@@ -16,5 +23,28 @@ pub fn fairing() -> impl Fairing {
         engines
             .tera
             .register_filter("linebreaksbr", filters::linebreaksbr);
+
+        // Register custom functions
+        let config = config.clone();
+        engines
+            .tera
+            .register_function("plausible_config", move |_args: &HashMap<String, Value>| {
+                // If plausible – a privacy-preserving, non-personal-data-logging,
+                // GDPR-compliant visitor stats software – is enabled in the config, return
+                // its configuration values.
+                if let Config {
+                    plausible_domain: Some(ref domain),
+                    plausible_url: Some(ref url),
+                    ..
+                } = *config
+                {
+                    let mut map = tera::Map::new();
+                    map.insert("url".into(), Value::String(url.to_string()));
+                    map.insert("domain".into(), Value::String(domain.to_string()));
+                    Ok(Value::Object(map))
+                } else {
+                    Ok(Value::Null)
+                }
+            });
     })
 }

--- a/templates/base.html.tera
+++ b/templates/base.html.tera
@@ -11,6 +11,12 @@
         <script src="/static/js/common.js"></script>
         <script src="/static/js/navbar.js"></script>
         <script src="/static/js/elements.flagmeister.min.js"></script>
+
+        {% set plausible = plausible_config() %}
+        {% if plausible %}
+        <!-- self-hosted, GDPR compliant, non-privacy-invading visitor stats -->
+        <script defer data-domain="{{ plausible.domain }}" src="{{ plausible.url | safe }}"></script>
+        {% endif %}
     </head>
     <body>
         <!-- Navbar -->


### PR DESCRIPTION
Plausible is a privacy-preserving, non-personal-data-logging, self-hostable, GDPR-compliant visitor stats software.

To enable, set the ROCKET_PLAUSIBLE_DOMAIN and ROCKET_PLAUSIBLE_URL env vars.