### PR TITLE
CI: Restructure with reusable workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,5 @@
 on:
-  push:
-    branches: [main]
+  workflow_call:
   pull_request:
   schedule:
     - cron: '30 3 * * 2'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,6 +1,5 @@
 on:
-  push:
-    branches: [main]
+  workflow_call:
   pull_request:
   schedule:
     - cron: '30 3 * * 2'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,18 @@
 on:
-  workflow_run:
-    workflows: [backend, frontend]
+  push:
     branches: [main]
-    types: [completed]
 
 name: Publish
 
 jobs:
+  test_backend:
+    uses: ./.github/workflows/backend.yml
+  test_frontend:
+    uses: ./.github/workflows/frontend.yml
   docker_image:
     name: Build Docker image
+    needs: [test_backend, test_frontend]
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker image


### PR DESCRIPTION
Instead of triggering multiple workflows on the main branch, trigger tests on PRs and only the publish workflow on the main branch. The publish workflow then calls the two test workflows.

See:

- https://stackoverflow.com/questions/75584775/trigger-a-github-workflow-if-two-other-workflows-have-been-successful
- https://stackoverflow.com/questions/58457140/dependencies-between-workflows-on-github-actions

Fixes #142.