### PR TITLE
Omit all optional keys when missing in API responses

### DIFF
--- a/src/gliders.rs
+++ b/src/gliders.rs
@@ -85,6 +85,7 @@ pub struct ApiGliders {
     /// List of user's gliders.
     gliders: Vec<ApiGlider>,
     /// The user's last used glider ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
     last_glider_id: Option<i32>,
 }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -19,6 +19,7 @@ pub struct ApiProfile {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiProfileUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
     news_opt_in: Option<bool>,
 }
 


### PR DESCRIPTION
Fixes #157.