### PR TITLE
Fix location add/edit messages

### DIFF
--- a/frontend/src/routes/locations/LocationForm.svelte
+++ b/frontend/src/routes/locations/LocationForm.svelte
@@ -126,8 +126,8 @@
           addFlash({
             message:
               location === undefined
-                ? $i18n.t('location.prose--add-success')
-                : $i18n.t('location.prose--update-success'),
+                ? $i18n.t('location.prose--add-success', {name})
+                : $i18n.t('location.prose--update-success', {name}),
             severity: 'success',
             icon: 'fa-circle-check',
           });

--- a/frontend/src/translations/de/translation.json
+++ b/frontend/src/translations/de/translation.json
@@ -217,7 +217,7 @@
     "error--longitude-empty": "Wenn der Breitengrad definiert ist, darf der Längengrad nicht leer sein",
     "error--name-empty": "Name darf nicht leer sein",
     "error--update-error": "Der Standort konnte aufgrund eines Serverfehlers nicht aktualisiert werden: {message}",
-    "prose--add-success": "Standort erfolgreich hinzugefügt",
+    "prose--add-success": "Standort «{name}» erfolgreich hinzugefügt",
     "prose--hint-double-click": "Hinweis: Ein Doppelklick oder Doppeltippen auf der Karte aktualisiert die Koordinaten.",
     "prose--update-success": "Standort «{name}» erfolgreich aktualisiert",
     "title--associated-flights": "Flüge an diesem Ort",

--- a/frontend/src/translations/en/translation.json
+++ b/frontend/src/translations/en/translation.json
@@ -217,7 +217,7 @@
     "error--longitude-empty": "If latitude is set, longitude must not be empty",
     "error--name-empty": "Name must not be empty",
     "error--update-error": "The location could not be updated due to an error on the server: {message}",
-    "prose--add-success": "Location successfully added",
+    "prose--add-success": "Location “{name}” successfully added",
     "prose--hint-double-click": "Note: Double-click or double-tap on the map to update the location coordinates.",
     "prose--update-success": "Location “{name}” successfully updated",
     "title--associated-flights": "Associated Flights",


### PR DESCRIPTION
When adding or editing a location, properly include the location name in the flash message.

Fixes #178.