### PR TITLE
FlightLogging: improve date setting behaviour

### DIFF
--- a/frontend/src/lib/time-helpers.test.ts
+++ b/frontend/src/lib/time-helpers.test.ts
@@ -1,0 +1,173 @@
+import {describe, it, expect} from 'vitest';
+
+import {
+    timeToMinutes,
+    minutesToTime,
+    hmsToTime,
+    calculateFlightDuration,
+    ymdToDateString,
+    isTimeBefore,
+} from './time-helpers';
+
+describe('timeToMinutes', () => {
+    const testCases = [
+        ['00:00', 0],
+        ['00:01', 1],
+        ['00:59', 59],
+        ['01:00', 60],
+        ['01:30', 90],
+        ['12:00', 720],
+        ['23:59', 1439],
+    ] as const;
+
+    for (const [time, expected] of testCases) {
+        it(`converts ${time} to ${expected} minutes`, () => {
+            expect(timeToMinutes(time)).to.equal(expected);
+        });
+    }
+});
+
+describe('minutesToTime', () => {
+    const testCases = [
+        [0, '00:00'],
+        [1, '00:01'],
+        [59, '00:59'],
+        [60, '01:00'],
+        [90, '01:30'],
+        [720, '12:00'],
+        [1439, '23:59'],
+    ] as const;
+
+    for (const [minutes, expected] of testCases) {
+        it(`converts ${minutes} minutes to ${expected}`, () => {
+            expect(minutesToTime(minutes)).to.equal(expected);
+        });
+    }
+});
+
+describe('hmsToTime', () => {
+    it('converts HMS with zero seconds', () => {
+        expect(hmsToTime([12, 30, 0])).to.equal('12:30');
+    });
+
+    it('converts HMS with seconds < 30 (rounds down)', () => {
+        expect(hmsToTime([12, 30, 25])).to.equal('12:30');
+    });
+
+    it('converts HMS with seconds >= 30 (rounds up)', () => {
+        expect(hmsToTime([12, 30, 35])).to.equal('12:31');
+    });
+
+    it('handles minute overflow when rounding seconds', () => {
+        expect(hmsToTime([12, 59, 30])).to.equal('13:00');
+    });
+
+    it('handles hour overflow when rounding seconds at 23:59', () => {
+        expect(hmsToTime([23, 59, 30])).to.equal('24:00');
+    });
+
+    it('converts midnight', () => {
+        expect(hmsToTime([0, 0, 0])).to.equal('00:00');
+    });
+
+    it('converts typical launch time', () => {
+        expect(hmsToTime([14, 23, 45])).to.equal('14:24');
+    });
+});
+
+describe('calculateFlightDuration', () => {
+    it('calculates duration for same day flight', () => {
+        expect(calculateFlightDuration('12:00', '14:30')).to.equal('+2:30');
+    });
+
+    it('calculates duration for short flight', () => {
+        expect(calculateFlightDuration('10:15', '10:45')).to.equal('+0:30');
+    });
+
+    it('calculates duration for long flight', () => {
+        expect(calculateFlightDuration('09:00', '16:30')).to.equal('+7:30');
+    });
+
+    it('handles day rollover (midnight crossing)', () => {
+        expect(calculateFlightDuration('23:00', '01:00')).to.equal('+2:00');
+    });
+
+    it('handles day rollover with minutes', () => {
+        expect(calculateFlightDuration('23:45', '00:15')).to.equal('+0:30');
+    });
+
+    it('returns undefined when start time is empty', () => {
+        expect(calculateFlightDuration('', '14:30')).to.be.undefined;
+    });
+
+    it('returns undefined when end time is empty', () => {
+        expect(calculateFlightDuration('12:00', '')).to.be.undefined;
+    });
+
+    it('returns undefined when both times are empty', () => {
+        expect(calculateFlightDuration('', '')).to.be.undefined;
+    });
+
+    it('calculates zero duration for same time', () => {
+        expect(calculateFlightDuration('12:00', '12:00')).to.equal('+0:00');
+    });
+
+    it('calculates one minute duration', () => {
+        expect(calculateFlightDuration('12:00', '12:01')).to.equal('+0:01');
+    });
+
+    it('formats hours with single digit', () => {
+        expect(calculateFlightDuration('10:00', '15:00')).to.equal('+5:00');
+    });
+
+    it('formats hours with double digits', () => {
+        expect(calculateFlightDuration('08:00', '20:30')).to.equal('+12:30');
+    });
+});
+
+describe('ymdToDateString', () => {
+    const testCases: Array<[[number, number, number], string]> = [
+        [[2024, 1, 1], '2024-01-01'],
+        [[2024, 12, 31], '2024-12-31'],
+        [[2024, 3, 15], '2024-03-15'],
+        [[2025, 10, 14], '2025-10-14'],
+        [[2000, 2, 29], '2000-02-29'], // Leap year
+    ];
+
+    for (const [ymd, expected] of testCases) {
+        it(`converts [${ymd.join(', ')}] to ${expected}`, () => {
+            expect(ymdToDateString(ymd)).to.equal(expected);
+        });
+    }
+});
+
+describe('isTimeBefore', () => {
+    it('returns true when first time is before second', () => {
+        expect(isTimeBefore('10:00', '11:00')).to.be.true;
+    });
+
+    it('returns true when first time is one minute before', () => {
+        expect(isTimeBefore('10:59', '11:00')).to.be.true;
+    });
+
+    it('returns false when first time is after second', () => {
+        expect(isTimeBefore('11:00', '10:00')).to.be.false;
+    });
+
+    it('returns false when times are equal', () => {
+        expect(isTimeBefore('10:00', '10:00')).to.be.false;
+    });
+
+    it('returns true for midnight vs morning', () => {
+        expect(isTimeBefore('00:00', '06:00')).to.be.true;
+    });
+
+    it('returns true for morning vs afternoon', () => {
+        expect(isTimeBefore('09:30', '14:45')).to.be.true;
+    });
+
+    it('returns false for evening vs morning (no day rollover handling)', () => {
+        // Note: This function compares times within the same day only
+        expect(isTimeBefore('23:00', '01:00')).to.be.false;
+    });
+});

--- a/frontend/src/lib/time-helpers.ts
+++ b/frontend/src/lib/time-helpers.ts
@@ -1,0 +1,86 @@
+/**
+ * Time utility functions for flight data processing
+ */
+
+/**
+ * Convert HH:MM time string to total minutes since midnight
+ * @param time Time in "HH:MM" format
+ * @returns Total minutes since midnight
+ */
+export function timeToMinutes(time: string): number {
+    const [hours, minutes] = time.split(':').map((v) => parseInt(v, 10));
+    return hours * 60 + minutes;
+}
+
+/**
+ * Convert minutes since midnight to HH:MM time string
+ * @param minutes Total minutes since midnight
+ * @returns Time in "HH:MM" format
+ */
+export function minutesToTime(minutes: number): string {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Convert HMS array (from IGC data) to HH:MM time string
+ * @param hms Tuple of [hours, minutes, seconds]
+ * @returns Time in "HH:MM" format (seconds are rounded into minutes)
+ */
+export function hmsToTime(hms: [number, number, number]): string {
+    let hours = hms[0];
+    let minutes = Math.round(hms[1] + hms[2] / 60);
+    if (minutes === 60) {
+        minutes = 0;
+        hours += 1;
+    }
+    return minutesToTime(hours * 60 + minutes);
+}
+
+/**
+ * Calculate duration between two times (handles day rollover)
+ * @param startTime Launch time in "HH:MM" format
+ * @param endTime Landing time in "HH:MM" format
+ * @returns Duration string in "+H:MM" format, or undefined if either time is empty
+ */
+export function calculateFlightDuration(startTime: string, endTime: string): string | undefined {
+    if (startTime === '' || endTime === '') {
+        return undefined;
+    }
+
+    const start = timeToMinutes(startTime);
+    const end = timeToMinutes(endTime);
+    let duration = end - start;
+
+    // Handle day rollover (e.g., 23:00 to 01:00)
+    if (duration < 0) {
+        duration += 1440; // 24 hours in minutes
+    }
+
+    const hours = Math.floor(duration / 60);
+    const minutes = (duration % 60).toString().padStart(2, '0');
+    return `+${hours}:${minutes}`;
+}
+
+/**
+ * Convert YMD array to ISO date string (YYYY-MM-DD)
+ * @param ymd Tuple of [year, month, day]
+ * @returns ISO date string
+ */
+export function ymdToDateString(ymd: [number, number, number]): string {
+    const [year, month, day] = ymd;
+    const m = month.toString().padStart(2, '0');
+    const d = day.toString().padStart(2, '0');
+    return `${year}-${m}-${d}`;
+}
+
+/**
+ * Check if one time is before another
+ * @param time1 First time in "HH:MM" format
+ * @param time2 Second time in "HH:MM" format
+ * @returns True if time1 is before time2
+ */
+export function isTimeBefore(time1: string, time2: string): boolean {
+    return timeToMinutes(time1) < timeToMinutes(time2);
+}


### PR DESCRIPTION
# Issue
if logging a flight manually, the time fields were not auto-populated, meaning you had to enter a time even if you didnt care about the flight time because it was a quick afternoon glide. 
also when logging a time it was a hassle because you had to set it twice, even if the flight was just a half a hour. (was more a problem on mobile with the scrolling time)


https://github.com/user-attachments/assets/a7ceb0a2-fa8f-4dba-8334-1235e2a5ab6a

# Solution
- Auto populate the Date to be Today and Time as 0:00
- if setting a takeoff time, the landing time is set to the same time, making it much faster to log times accurately as you are already in the correct range of times (mobile scrolling)

https://github.com/user-attachments/assets/650199ac-018e-4fe7-910e-bfd53e3dcce8


## Additional
- extracted time functionalities into an helper function with tests. 
- igc uploads overwrite manual date and time setting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flight form now automatically adjusts landing time if set earlier than launch time
  * IGC file uploads automatically populate flight date, times, locations, and distance from file metadata
  * Flight form defaults improved with today's date and standard time values

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->